### PR TITLE
Add try-except block to catch when EventTime is None

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -127,19 +127,24 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
                                     params=params,
                                     item_key="EventId"):
             start = self.toTime(api_event['EventDate'])
-            start_time = time.strptime(api_event['EventTime'], '%I:%M %p')
-            api_event['start'] = start.replace(hour=start_time.tm_hour,
-                                               minute=start_time.tm_min)
-            api_event['status'] = confirmed_or_passed(api_event['start'])
-
-            key = (api_event['EventBodyName'].strip(),
-                   api_event['start'])
-
+            # EventTime may be 'None': this try-except block catches those instances.
             try:
-                web_event = web_results[key]
-                yield api_event, web_event
-            except KeyError:
+                start_time = time.strptime(api_event['EventTime'], '%I:%M %p')
+            except TypeError:
                 continue
+            else:
+                api_event['start'] = start.replace(hour=start_time.tm_hour,
+                                                   minute=start_time.tm_min)
+                api_event['status'] = confirmed_or_passed(api_event['start'])
+
+                key = (api_event['EventBodyName'].strip(),
+                       api_event['start'])
+
+                try:
+                    web_event = web_results[key]
+                    yield api_event, web_event
+                except KeyError:
+                    continue
             
 
     def agenda(self, event):


### PR DESCRIPTION
@fgregg This fix responds to the recent errors thrown by the Chicago events scraper. 

We should not have an event without a start time: so, I added a try-except block that continues without yielding the api event.

I used the patterns suggested here: https://github.com/opencivicdata/python-legistar-scraper/pull/28#pullrequestreview-43285771