### PR TITLE
Add relations method for scraping related bills

### DIFF
--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -238,6 +238,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper) :
     topics = partialmethod(endpoint, '/matters/{0}/indexes')
     attachments = partialmethod(endpoint, '/matters/{0}/attachments')
     code_sections = partialmethod(endpoint, 'matters/{0}/codesections')
+    relations = partialmethod(endpoint, '/matters/{0}/relations')
 
     def votes(self, history_id) :
         url = self.BASE_URL + '/eventitems/{0}/votes'.format(history_id)


### PR DESCRIPTION
This PR adds a `relations` method, which allows for iteration over all matter relations on a bill, e.g., http://webapi.legistar.com/v1/metro/matters/4089/relations