### PR TITLE
LegistarSession class to raise appropriate errors

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -19,7 +19,10 @@ class LegistarSession(requests.Session):
         print('Sending request to {} with the {} method...'.format(url, method))
         # When we resend the POST request via `lxmlize`, we get the expected data, i.e., with "All Years" selected: https://github.com/reginafcompton/python-legistar-scraper/blob/5dedec530d93d1713155c6f61ce45df2b9090354/legistar/base.py#L20
         # However, when we retry via the RetrySession Class, the POST AssertionError persists. 
-        # The difference? lxmlize simply sends a new POST. It does not create a new session: the cookies persist between POST requests. 
+        # The difference? lxmlize simply sends a new POST. It does not create a new session.
+        # Some oddities: when the AssertionError disappears on the made-from-scratch retry, one of the Cookies disappears - [<Cookie BIGipServerprod_insite_443=874644234.47873.0000 for metro.legistar.com/>
+        # However, this cookie also appears when the Assertion succeeds without a retry...so, the cookie itself does not seem to be the cause of the problem. 
+
         response = super(LegistarSession, self).request(method, url, **kwargs)
         payload = kwargs.get('data')
 

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -17,9 +17,10 @@ class LegistarSession(requests.Session):
 
     def request(self, method, url, **kwargs):
         print('Sending request to {} with the {} method...'.format(url, method))
+
         # Creates a new session with a payload and verify=False...
         # ...but the post request seems to be different than it is in lxmlize: https://github.com/reginafcompton/python-legistar-scraper/blob/5dedec530d93d1713155c6f61ce45df2b9090354/legistar/base.py#L20
-        # It seems that the below is exactly the same as: requests.post(url, payload, verify=False)
+        # the difference? requests.post(url, payload, verify=False) returns different headers? lxmlize does not create a new session, so the cookies persist....?
         response = super(LegistarSession, self).request(method, url, **kwargs)
         payload = kwargs.get('data')
 

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -17,10 +17,9 @@ class LegistarSession(requests.Session):
 
     def request(self, method, url, **kwargs):
         print('Sending request to {} with the {} method...'.format(url, method))
-
-        # Creates a new session with a payload and verify=False...
-        # ...but the post request seems to be different than it is in lxmlize: https://github.com/reginafcompton/python-legistar-scraper/blob/5dedec530d93d1713155c6f61ce45df2b9090354/legistar/base.py#L20
-        # the difference? requests.post(url, payload, verify=False) returns different headers? lxmlize does not create a new session, so the cookies persist....?
+        # When we resend the POST request via `lxmlize`, we get the expected data, i.e., with "All Years" selected: https://github.com/reginafcompton/python-legistar-scraper/blob/5dedec530d93d1713155c6f61ce45df2b9090354/legistar/base.py#L20
+        # However, when we retry via the RetrySession Class, the POST AssertionError persists. 
+        # The difference? lxmlize simply sends a new POST. It does not create a new session: the cookies persist between POST requests. 
         response = super(LegistarSession, self).request(method, url, **kwargs)
         payload = kwargs.get('data')
 

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -16,9 +16,11 @@ import pytz
 class LegistarSession(requests.Session):
 
     def request(self, method, url, **kwargs):
-        print('getting a response...')
+        print('Request: getting a response...')
         response = super(LegistarSession, self).request(method, url, **kwargs)
         payload = kwargs.get('data')
+        # if payload :
+        #     response = self.post(url, payload, verify=False)
 
         self._check_errors(response, payload)
 
@@ -37,28 +39,14 @@ class LegistarSession(requests.Session):
         if self.check_time_range(payload):
             self.search_range_error(response)
 
-        # elif self.check_time_range(payload):
-        #     page = lxml.html.fromstring(response.text)
-        #     time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
-        #     if time_range.value != "All Years":
-        #         print("alll years failure")
-        #         response.status_code = 520
-        #     else:
-        #         return None
-        # else:
-        #     return None
-        
-        # raise scrapelib.HTTPError(response)
-
     def search_range_error(self, response):
         page = lxml.html.fromstring(response.text)
         time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
         if time_range.value != "All Years":
-            print("alll years failure")
+            print("ERROR: alll years failure")
             response.status_code = 520
 
         raise scrapelib.HTTPError(response)
-
     # Determines if we sent a post request looking for "All Years"
     def check_time_range(self, payload):
         if payload:

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -19,11 +19,12 @@ class LegistarSession(requests.Session):
         print('Sending request to {} with the {} method...'.format(url, method))
         # When we resend the POST request via `lxmlize`, we get the expected data, i.e., with "All Years" selected: https://github.com/reginafcompton/python-legistar-scraper/blob/5dedec530d93d1713155c6f61ce45df2b9090354/legistar/base.py#L20
         # However, when we retry via the RetrySession Class, the POST AssertionError persists. 
-        # The difference? lxmlize simply sends a new POST. It does not create a new session.
+        # The difference? The cookies.
         # Some oddities: when the AssertionError disappears on the made-from-scratch retry, one of the Cookies disappears - [<Cookie BIGipServerprod_insite_443=874644234.47873.0000 for metro.legistar.com/>
         # However, this cookie also appears when the Assertion succeeds without a retry...so, the cookie itself does not seem to be the cause of the problem. 
 
         response = super(LegistarSession, self).request(method, url, **kwargs)
+        print(response.cookies)
         payload = kwargs.get('data')
 
         self._check_errors(response, payload)
@@ -46,8 +47,9 @@ class LegistarSession(requests.Session):
     def search_range_error(self, response):
         page = lxml.html.fromstring(response.text)
         time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
+        time_range = time_range.value
+        print("Time range: {}".format(time_range))
         if time_range.value != "All Years":
-            print("ERROR: alll years failure")
             response.status_code = 520
 
         raise scrapelib.HTTPError(response)

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -63,7 +63,7 @@ class LegistarSession(requests.Session):
     def _range_is_all(self, payload):
         range_var = 'ctl00_ContentPlaceHolder1_lstYears_ClientState'
         all_range = (range_var in payload and
-                         json.loads(payload[range_var])['value'] == 'All')
+                     json.loads(payload[range_var])['value'] == 'All')
         return all_range
         
 

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -3,6 +3,8 @@ import itertools
 import traceback
 from collections import defaultdict, deque
 import re
+import requests
+import json
 
 import scrapelib
 from pupa.scrape import Scraper
@@ -10,29 +12,63 @@ import lxml.html
 import lxml.etree as etree
 import pytz
 
-class LegistarScraper(Scraper, LegistarScraper):
+
+class LegistarSession(requests.Session):
+
+    def request(self, method, url, **kwargs):
+        response = super(LegistarSession, self).request(method, url, **kwargs)
+        payload = kwargs.get('data')
+
+        self._check_errors(response, payload)
+
+        return response
+
+    def _check_errors(self, response, payload=None):
+        if response.url.endswith('Error.aspx'):
+            response.status_code = 503
+        elif not response.text:
+            response.status_code = 520
+        # Legistar intermittently does not return the expected response when selecting "All Years" - instead, it returns "This Month"
+        # Raise an HTTPError in such cases.
+        elif self.check_time_range(payload):
+            page = lxml.html.fromstring(response.text)
+            time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
+            if time_range.value != "All Years":
+                response.status_code = 520
+            else:
+                return None
+        else:
+            return None
+        
+        raise scrapelib.HTTPError(response)
+
+    # Determines if we sent a post request looking for "All Years"
+    def check_time_range(self, payload):
+        if payload:
+            value_dict = json.loads(payload['ctl00_ContentPlaceHolder1_lstYears_ClientState'])
+            return value_dict['value'] == 'All'
+        
+
+class LegistarScraper(Scraper, LegistarSession):
     date_format='%m/%d/%Y'
 
     def __init__(self, *args, **kwargs) :
         super(LegistarScraper, self).__init__(*args, **kwargs)
         self.timeout = 600
 
-    # Accept value
-    def lxmlize(self, url, payload=None, value=None):
+    def lxmlize(self, url, payload=None):
         if payload :
             response = self.post(url, payload, verify=False)
         else :
             response = self.get(url, verify=False)
-        # Pass value here...so I know if "All" could trigger an AssertionError
-        self._check_errors(response, value)
+        self._check_errors(response)
         entry = response.text
         page = lxml.html.fromstring(entry)
         page.make_links_absolute(url)
         return page
 
-    # Accept value
-    def pages(self, url, payload=None, value=None) :
-        page = self.lxmlize(url, payload, value)
+    def pages(self, url, payload=None) :
+        page = self.lxmlize(url, payload)
         
         yield page
 
@@ -184,15 +220,15 @@ class LegistarScraper(Scraper, LegistarScraper):
 
         return(payload)
 
-    def _check_errors(self, response):
-        if response.url.endswith('Error.aspx'):
-            response.status_code = 503
-        elif not response.text:
-            response.status_code = 520
-        else:
-            return None
+    # def _check_errors(self, response):
+    #     if response.url.endswith('Error.aspx'):
+    #         response.status_code = 503
+    #     elif not response.text:
+    #         response.status_code = 520
+    #     else:
+    #         return None
         
-        raise scrapelib.HTTPError(response)
+    #     raise scrapelib.HTTPError(response)
 
 
 def fieldKey(x) :
@@ -227,27 +263,3 @@ class LegistarAPIScraper(Scraper):
                     seen.append(item[item_key])
 
             page_num += 1
-
-class LegistarSession(requests.Session):
-
-    def request(self, method, url, **kwargs):
-        response = super(LegistarSession, self).request(method, url, **kwargs)
-        self._check_errors(response)
-        return response
-
-    # How can we know if we are looking for "All"? This info would be in the payload, or we could pass it in as an argument to pages and lxmlize (i.e., pages(value=None), lxmlize(value=None))....
-    # Then, allow check_errors to take in "value" as an arg, too.
-    def _check_errors(self, response, value=None):
-        if response.url.endswith('Error.aspx'):
-            response.status_code = 503
-        elif not response.text:
-            response.status_code = 520
-        elif value == 'All':
-            page = lxml.html.fromstring(response.text)
-            time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
-            if time_range.value != "All Years":
-                response.status_code = 520
-        else:
-            return None
-        
-        raise scrapelib.HTTPError(response)

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -16,11 +16,12 @@ import pytz
 class LegistarSession(requests.Session):
 
     def request(self, method, url, **kwargs):
-        print('Request: getting a response...')
+        print('Sending request to {} with the {} method...'.format(url, method))
+        # Creates a new session with a payload and verify=False...
+        # ...but the post request seems to be different than it is in lxmlize: https://github.com/reginafcompton/python-legistar-scraper/blob/5dedec530d93d1713155c6f61ce45df2b9090354/legistar/base.py#L20
+        # It seems that the below is exactly the same as: requests.post(url, payload, verify=False)
         response = super(LegistarSession, self).request(method, url, **kwargs)
         payload = kwargs.get('data')
-        # if payload :
-        #     response = self.post(url, payload, verify=False)
 
         self._check_errors(response, payload)
 

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -25,9 +25,6 @@ class LegistarEventsScraper(LegistarScraper):
 
         if since is None :
             for page in self.eventSearch(page, 'All'):
-                # time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
-                # time_range = time_range.value
-                # assert time_range == "All Years"
                 yield page
         else :
             for year in range(since, self.now().year + 1) :

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -45,6 +45,7 @@ class LegistarEventsScraper(LegistarScraper):
         payload = self.sessionSecrets(page)
 
         payload['ctl00_ContentPlaceHolder1_lstYears_ClientState'] = '{"value":"%s"}' % value
+        
         payload['__EVENTTARGET'] = 'ctl00$ContentPlaceHolder1$lstYears'
 
         return self.pages(self.EVENTSPAGE, payload)

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -36,9 +36,14 @@ class LegistarEventsScraper(LegistarScraper):
     def eventSearch(self, page, value) :
         payload = self.sessionSecrets(page)
 
-        payload['ctl00_ContentPlaceHolder1_lstYears_ClientState'] = '{"value":"%s"}' % value
+        # payload['ctl00_ContentPlaceHolder1_lstYears_ClientState'] = '{"value":"%s"}' % value
+
+        if (value == 'All'):
+            payload['ctl00_ContentPlaceHolder1_lstYears_ClientState'] = '{"value":%s, "text":%s}' % ('All', 'All Years')
+            payload['__EVENTARGUMENT'] = '{ "Command":"Select", "Index":0 }'
 
         payload['__EVENTTARGET'] = 'ctl00$ContentPlaceHolder1$lstYears'
+
 
         return self.pages(self.EVENTSPAGE, payload)
 

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -18,7 +18,6 @@ class LegistarEventsScraper(LegistarScraper):
         # use a cached page, which may have expired .NET state values,
         # even in fastmode (which uses the cache).
         response = requests.get(self.EVENTSPAGE, verify=False)
-        self._check_errors(response)
         entry = response.text
         page = lxml.html.fromstring(entry)
         page.make_links_absolute(self.EVENTSPAGE)
@@ -197,8 +196,7 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
 
         for event, _ in web_scraper.events(follow_links=False):
             # Make the dict key (name, datetime.datetime), and add it.
-            response = self.get(event['iCalendar']['url'], verify=False)
-            web_scraper._check_errors(response)
+            response = web_scraper.get(event['iCalendar']['url'], verify=False)
             event_time = web_scraper.ical(response.text).subcomponents[0]['DTSTART'].dt
             event_time = pytz.timezone(self.TIMEZONE).localize(event_time)
 

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -24,12 +24,10 @@ class LegistarEventsScraper(LegistarScraper):
         page.make_links_absolute(self.EVENTSPAGE)
 
         if since is None :
-            # Legistar intermittently does not return the expected response, which raises an AssertionError.
-            # In such cases, try once to resend the POST request (via eventSearch --> pages --> lxmlize). 
             for page in self.eventSearch(page, 'All'):
-                time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
-                time_range = time_range.value
-                assert time_range == "All Years"
+                # time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
+                # time_range = time_range.value
+                # assert time_range == "All Years"
                 yield page
         else :
             for year in range(since, self.now().year + 1) :
@@ -42,8 +40,7 @@ class LegistarEventsScraper(LegistarScraper):
 
         payload['__EVENTTARGET'] = 'ctl00$ContentPlaceHolder1$lstYears'
 
-        # Pass in value
-        return self.pages(self.EVENTSPAGE, payload, value)
+        return self.pages(self.EVENTSPAGE, payload)
 
     def events(self, follow_links=True, since=None) :
         # If an event is added to the the legistar system while we

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -25,18 +25,12 @@ class LegistarEventsScraper(LegistarScraper):
 
         if since is None :
             # Legistar intermittently does not return the expected response, which raises an AssertionError.
-            # In such cases, try once to resend the POST request (via eventSearch --> pages --> lxmlize).
-            for i in range(0,2):
-                try:
-                    for page in self.eventSearch(page, 'All'):
-                        time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
-                        time_range = time_range.value
-                        assert time_range == "All Years"
-                        yield page
-                except AssertionError:
-                    continue
-                else:
-                    break
+            # In such cases, try once to resend the POST request (via eventSearch --> pages --> lxmlize). 
+            for page in self.eventSearch(page, 'All'):
+                time_range, = page.xpath("//input[@id='ctl00_ContentPlaceHolder1_lstYears_Input']")
+                time_range = time_range.value
+                assert time_range == "All Years"
+                yield page
         else :
             for year in range(since, self.now().year + 1) :
                 yield from self.eventSearch(page, str(year))
@@ -45,10 +39,11 @@ class LegistarEventsScraper(LegistarScraper):
         payload = self.sessionSecrets(page)
 
         payload['ctl00_ContentPlaceHolder1_lstYears_ClientState'] = '{"value":"%s"}' % value
-        
+
         payload['__EVENTTARGET'] = 'ctl00$ContentPlaceHolder1$lstYears'
 
-        return self.pages(self.EVENTSPAGE, payload)
+        # Pass in value
+        return self.pages(self.EVENTSPAGE, payload, value)
 
     def events(self, follow_links=True, since=None) :
         # If an event is added to the the legistar system while we


### PR DESCRIPTION
Scrapelib has some nice facilities for retrying a request if it runs into a HTTP error. However, legistar does not return the right error values in some places. 

This PR creates a new class that we can mixin to the LegistarScraper that will make the request return an appropriate error so that Scrapelib can do the right thing for retrying.

It also makes some of the code a little easier to read. Closes #46 and supersedes #49