### PR TITLE
Handle case where sponsor matter version is asterisk

### DIFF
--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -267,12 +267,23 @@ class LegistarAPIBillScraper(LegistarAPIScraper) :
     def sponsors(self, matter_id) :
         spons = self.endpoint('/matters/{0}/sponsors', matter_id)
         if spons:
-            max_version = str(max(int(sponsor['MatterSponsorMatterVersion'])
-                              for sponsor in spons))
-            spons = [sponsor for sponsor in spons
-                     if sponsor['MatterSponsorMatterVersion'] == max_version]
-            return sorted(spons, 
+            try:
+                max_version = str(max(int(sponsor['MatterSponsorMatterVersion'])
+                                  for sponsor in spons))
+
+            except ValueError:
+                if sponsor['MatterSponsorMatterVersion'] == '*':
+                    spons = [sponsor for sponsor in spons]
+                else:
+                    raise
+
+            else:
+                spons = [sponsor for sponsor in spons
+                         if sponsor['MatterSponsorMatterVersion'] == max_version]
+
+            return sorted(spons,
                           key = lambda sponsor : sponsor["MatterSponsorSequence"])
+
         else:
             return []
 

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -267,25 +267,24 @@ class LegistarAPIBillScraper(LegistarAPIScraper) :
     def sponsors(self, matter_id) :
         spons = self.endpoint('/matters/{0}/sponsors', matter_id)
         if spons:
-            try:
-                max_version = str(max(int(sponsor['MatterSponsorMatterVersion'])
-                                  for sponsor in spons))
+            max_version = max(self._version_rank(sponsor['MatterSponsorMatterVersion'])
+                              for sponsor in spons)
 
-            except ValueError:
-                if sponsor['MatterSponsorMatterVersion'] == '*':
-                    spons = [sponsor for sponsor in spons]
-                else:
-                    raise
-
-            else:
-                spons = [sponsor for sponsor in spons
-                         if sponsor['MatterSponsorMatterVersion'] == max_version]
+            spons = [sponsor for sponsor in spons
+                     if sponsor['MatterSponsorMatterVersion'] == str(max_version)]
 
             return sorted(spons,
                           key = lambda sponsor : sponsor["MatterSponsorSequence"])
 
         else:
             return []
+
+    def _version_rank(self, version) :
+        '''
+        In general, matter versions are numbers. This method provides an
+        override opportunity for handling versions that are not numbers.
+        '''
+        return int(version)
 
     def relations(self, matter_id):
         relations = self.endpoint('/matters/{0}/relations', matter_id)


### PR DESCRIPTION
In the NYC Legistar sponsorship API, `MatterSponsorMatterVersion` is often an asterisk, i.e.

```xml
<GranicusMatterSponsor>
<MatterSponsorBodyId i:nil="true"/>
<MatterSponsorGuid>FF22EF28-C7B9-48D9-8F80-7CAB42DEF2D4</MatterSponsorGuid>
<MatterSponsorId>361112</MatterSponsorId>
<MatterSponsorLastModifiedUtc>2015-08-25T15:58:09.02</MatterSponsorLastModifiedUtc>
<MatterSponsorLinkFlag>1</MatterSponsorLinkFlag>
<MatterSponsorMatterId>18233</MatterSponsorMatterId>
<MatterSponsorMatterVersion>*</MatterSponsorMatterVersion>
<MatterSponsorName>Wendell Foster</MatterSponsorName>
<MatterSponsorNameId>15</MatterSponsorNameId>
<MatterSponsorRowVersion>AAAAAAAQVTM=</MatterSponsorRowVersion>
<MatterSponsorSequence>3</MatterSponsorSequence>
</GranicusMatterSponsor>
```

This handles that case, while keeping the scraper fragile enough that it will break if it encounters something unexpected.