### PR TITLE
Apply API event window to embedded web calendar scrape

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -295,5 +295,5 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
         whether the given event is one of those cases, returning True if so, and
         False otherwise. Available for override in jurisdictional scrapers.
         '''
-        return event['EventAgendaStatusId'] == 1  # agenda not yet final
+        return False
 

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -225,7 +225,7 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
         web_scraper.EVENTSPAGE = self.EVENTSPAGE
         web_scraper.BASE_URL = self.WEB_URL
         web_scraper.TIMEZONE = self.TIMEZONE
-        web_scraper.date_format='%m/%d/%Y'
+        web_scraper.date_format = '%m/%d/%Y'
 
         for year in reversed(range(web_scraper.now().year + 1)):
             for event, _ in web_scraper.events(follow_links=False, since=year):

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -157,7 +157,7 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
             else:
                 api_event['start'] = start.replace(hour=start_time.tm_hour,
                                                    minute=start_time.tm_min)
-                api_event['status'] = confirmed_or_passed(api_event['start'])
+                api_event['status'] = self._event_status(api_event)
 
                 key = (api_event['EventBodyName'].strip(),
                        api_event['start'])
@@ -262,13 +262,17 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
         except ValueError :
             pass
 
+    def _event_status(self, event):
+        '''Events can have a status of tentative, confirmed, cancelled, or
+        passed (http://docs.opencivicdata.org/en/latest/data/event.html). By
+        default, set status to passed if the current date and time exceeds the
+        event date and time, or confirmed otherwise. Available for override in
+        jurisdictional scrapers.
+        '''
+        if datetime.datetime.utcnow().replace(tzinfo = pytz.utc) > event['start']:
+            status = 'passed'
+        else:
+            status = 'confirmed'
 
-    
-def confirmed_or_passed(when) :
-    if datetime.datetime.utcnow().replace(tzinfo = pytz.utc) > when :
-        status = 'confirmed'
-    else :
-        status = 'passed'
-    
-    return status
+        return status
 

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -22,12 +22,8 @@ class LegistarEventsScraper(LegistarScraper):
         page = lxml.html.fromstring(entry)
         page.make_links_absolute(self.EVENTSPAGE)
 
-        if since is None :
-            for page in self.eventSearch(page, 'All'):
-                yield page
-        else :
-            for year in range(since, self.now().year + 1) :
-                yield from self.eventSearch(page, str(year))
+        for page in self.eventSearch(page, since):
+            yield page
 
     def eventSearch(self, page, value) :
         payload = self.sessionSecrets(page)
@@ -55,7 +51,10 @@ class LegistarEventsScraper(LegistarScraper):
         else:
             since_year = 0
 
-        for year in range(self.now().year, since_year, -1):
+        # Anticipate events will be scheduled for the following year to avoid
+        # missing upcoming events during scrapes near the end of the current
+        # year.
+        for year in range(self.now().year + 1, since_year, -1):
             for page in self.eventPages(year) :
 
                 events_table = page.xpath("//table[@class='rgMasterTable']")[0]

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -164,8 +164,7 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
 
                 api_event['status'] = self._event_status(api_event)
 
-                # Skip events that do not appear in the web interface.
-                if api_event['EventAgendaStatusId'] == 1:
+                if self._not_in_web_interface(api_event):
                     continue
 
                 else:
@@ -276,4 +275,12 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
             status = 'confirmed'
 
         return status
+
+    def _not_in_web_interface(event):
+        '''Occasionally, an event will appear in the API, but not in the web
+        interface. This method checks attributes of the API event that tell us
+        whether the given event is one of those cases, returning True if so, and
+        False otherwise. Available for override in jurisdictional scrapers.
+        '''
+        return event['EventAgendaStatusId'] == 1  # agenda not yet final
 

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -116,23 +116,44 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
 
     def events(self, since_datetime=None):
         if since_datetime:
-            params = {'$filter' : "EventLastModifiedUtc gt datetime'{since_datetime}'".format(since_datetime = since_datetime.isoformat())}
+            # Minutes are often published after an event occurs – without a
+            # corresponding event modification. Query all update fields so later
+            # changes are always caught by our scraper, particularly when
+            # scraping narrower windows of time.
+            update_fields = ('EventLastModifiedUtc',
+                             'EventAgendaLastPublishedUTC',
+                             'EventMinutesLastPublishedUTC')
+
+            since_fmt = " gt datetime'{}'".format(since_datetime.isoformat())
+            since_filter = ' or '.join(field + since_fmt for field in update_fields)
+
+            params = {'$filter' : since_filter}
+
+            # Update data is not accessible via the web calendar. If a value for
+            # `since_datetime` is provided, scrape the preceding year onward so
+            # we don't wind up with missing events in early January, when our
+            # window might include a chunk of the prior year.
+            year_buffer = since_datetime.year - 1
         else:
             params = {}
+            year_buffer = None
 
         events_url = self.BASE_URL + '/events/'
 
-        web_results = self._scrapeWebCalendar(since_datetime.year)
+        web_results = self._scrapeWebCalendar(year_buffer)
 
         for api_event in self.pages(events_url,
                                     params=params,
                                     item_key="EventId"):
             start = self.toTime(api_event['EventDate'])
+
             # EventTime may be 'None': this try-except block catches those instances.
             try:
                 start_time = time.strptime(api_event['EventTime'], '%I:%M %p')
+
             except TypeError:
                 continue
+
             else:
                 api_event['start'] = start.replace(hour=start_time.tm_hour,
                                                    minute=start_time.tm_min)
@@ -144,9 +165,24 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
                 try:
                     web_event = web_results[key]
                     yield api_event, web_event
+
                 except KeyError:
-                    continue
-            
+                    # It is unlikely but possible for an event to be updated
+                    # long after it occurs, thus showing up when we query the API
+                    # by updated date while being excluded from the web calendar
+                    # scrape. If that occurs, fail loudly.
+
+                    _, event_date = key
+
+                    # Upcoming events sometimes appear in the API prior to the web
+                    # interface. Skip over events that fall within our buffer.
+                    if event_date.year >= year_buffer:
+                        continue
+
+                    else:
+                        api_event['url'] = events_url + api_event['EventId']
+                        error_fmt = '{EventBodyName} event dated {EventDate} not in web calendar scrape: {url}'
+                        raise KeyError(error_fmt.format(**api_event))
 
     def agenda(self, event):
         agenda_url = self.BASE_URL + '/events/{}/eventitems'.format(event['EventId'])

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -122,7 +122,7 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
 
         events_url = self.BASE_URL + '/events/'
 
-        web_results = self._scrapeWebCalendar()
+        web_results = self._scrapeWebCalendar(since_datetime.year)
 
         for api_event in self.pages(events_url,
                                     params=params,
@@ -182,7 +182,7 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
                 for item in response.json():
                     yield item
 
-    def _scrapeWebCalendar(self):
+    def _scrapeWebCalendar(self, since=None):
         web_scraper = LegistarEventsScraper(self.jurisdiction,
                                             self.datadir,
                                             strict_validation=self.strict_validation,
@@ -194,7 +194,7 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
 
         web_info = {}
 
-        for event, _ in web_scraper.events(follow_links=False):
+        for event, _ in web_scraper.events(follow_links=False, since=since):
             key = self._event_key(event, web_scraper)
             web_info[key] = event
 


### PR DESCRIPTION
`LegistarAPIEventScraper` accepts a `since_datetime` for filtering API events, but scrapes the entire web calendar regardless of the given window. This PR passes the year from `since_datetime` through to the associated web scraper so the whole web calendar need not be scraped for narrow event scrapes.

However, this may not be an entirely appropriate approach, since an event may be updated in a different year than it occurred and thus may show up in API results, but not in the narrowed web scrape. 

For example, if we provide a `since_datetime` of `2017-11-01` to the API scraper, this implementation will ask the web scraper to retrieve events from 2017 only. However, it is possible that an event from 2016 has been updated in the last month and so will appear in the API scrape but be missing from the web scrape.