### PR TITLE
Sort versions per version rank, but return actual version

### DIFF
--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -308,9 +308,12 @@ class LegistarAPIBillScraper(LegistarAPIScraper) :
 
     def sponsors(self, matter_id) :
         spons = self.endpoint('/matters/{0}/sponsors', matter_id)
+
         if spons:
-            max_version = max(self._version_rank(sponsor['MatterSponsorMatterVersion'])
-                              for sponsor in spons)
+            max_version = max(
+                (sponsor['MatterSponsorMatterVersion'] for sponsor in spons),
+                key = lambda version : self._version_rank(version)
+            )
 
             spons = [sponsor for sponsor in spons
                      if sponsor['MatterSponsorMatterVersion'] == str(max_version)]


### PR DESCRIPTION
The versioning code returns the "value" of the version, i.e., [1 rather than asterisk](https://github.com/opencivicdata/scrapers-us-municipal/blob/master/nyc/bills.py#L133), instead of the actual version, with the effect of scraping no sponsors in the NYC scraper (where versions are lettered, not numbered).

Use the actual version, [similar to the `text` method](https://github.com/opencivicdata/python-legistar-scraper/blob/master/legistar/bills.py#L350).