### PR TITLE
Rough in search method

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -253,6 +253,41 @@ class LegistarAPIScraper(Scraper):
         time = pytz.timezone(self.TIMEZONE).localize(time)
         return time
 
+    def search(self, route, item_key, search_conditions):
+        """
+        Base function for searching the Legistar API. You typically
+        will want to specialize this using by setting the route
+        and item key in a wrapper function.
+
+
+        Arguments:
+
+        route -- The path to search, i.e. /matters/, /events/, etc
+        item_key -- The unique id for the items that you are searching.
+                    This is necessary for proper pagination. examples
+                    might be MatterId or EventId
+        search_conditions -- a string in the OData format for the
+                             your search conditions http://www.odata.org/documentation/odata-version-3-0/url-conventions/#url5.1.2
+
+                             It would be nice if we could provide a
+                             friendly search API. Something like https://github.com/tuomur/python-odata
+        """
+
+        search_url = self.BASE_URL + route
+
+        params = {'$filter': search_conditions}
+
+        try:
+            yield from self.pages(search_url,
+                                  params=params,
+                                  item_key=item_key)
+        except requests.HTTPError as e:
+            if e.response.status_code == 400:
+                raise ValueError(e.response.json()['Message'])
+            raise
+
+
+
     def pages(self, url, params=None, item_key=None):
         if params is None:
             params = {}
@@ -263,6 +298,7 @@ class LegistarAPIScraper(Scraper):
         while page_num == 0 or len(response.json()) == 1000 :
             params['$skip'] = page_num * 1000
             response = self.get(url, params=params)
+            response.raise_for_status()
 
             for item in response.json() :
                 if item[item_key] not in seen :

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -259,11 +259,13 @@ class LegistarAPIScraper(Scraper):
         will want to specialize this using by setting the route
         and item key in a wrapper function.
 
+        If you were searching for matters, then this would looke like
+        search('/matters/', 'MatterId', your_search_condition)
 
         Arguments:
 
         route -- The path to search, i.e. /matters/, /events/, etc
-        item_key -- The unique id for the items that you are searching.
+        item_key -- The unique id field for the items that you are searching.
                     This is necessary for proper pagination. examples
                     might be MatterId or EventId
         search_conditions -- a string in the OData format for the

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -307,3 +307,11 @@ class LegistarAPIScraper(Scraper):
                     seen.append(item[item_key])
 
             page_num += 1
+
+    def accept_response(self, response, **kwargs):
+        '''
+        This overrides a method that controls whether
+        the scraper should retry on an error. We don't
+        want to retry if the API returns a 400
+        '''
+        return response.status_code < 401

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -287,7 +287,6 @@ class LegistarAPIScraper(Scraper):
             raise
 
 
-
     def pages(self, url, params=None, item_key=None):
         if params is None:
             params = {}

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -255,12 +255,7 @@ class LegistarAPIScraper(Scraper):
 
     def search(self, route, item_key, search_conditions):
         """
-        Base function for searching the Legistar API. You typically
-        will want to specialize this using by setting the route
-        and item key in a wrapper function.
-
-        If you were searching for matters, then this would looke like
-        search('/matters/', 'MatterId', your_search_condition)
+        Base function for searching the Legistar API.
 
         Arguments:
 
@@ -273,6 +268,11 @@ class LegistarAPIScraper(Scraper):
 
                              It would be nice if we could provide a
                              friendly search API. Something like https://github.com/tuomur/python-odata
+
+
+        Examples:
+        # Search for bills introduced after Jan. 1, 2017
+        search('/matters/', 'MatterId', "MatterIntroDate gt datetime'2017-01-01'")
         """
 
         search_url = self.BASE_URL + route

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -248,22 +248,6 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
                 if web_key == api_key:
                     return event
 
-    def endpoint(self, route, *args) :
-        url = self.BASE_URL + route
-        response = self.get(url.format(*args))
-        return response.json()
-
-    def search(self, **kwargs):
-        conditions = []
-        for k, v in kwargs:
-            if k.endswith('Date'):
-                condition = "{0} eq datetime'{1}'".format(k, v)
-            else:
-                condition = "{0} eq '{1}'".format(k, v)
-            conditions.append(condition)
-        params = ' and '.join(conditions)
-        return self.endpoint("/events/?$filter={0}", params)
-
     def _scrapeWebCalendar(self):
         '''Generator yielding events from Legistar in roughly reverse
         chronological order.

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -254,7 +254,14 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
         return response.json()
 
     def search(self, **kwargs):
-        params = ' and '.join("{0} eq '{1}'".format(k, v) for k, v in kwargs.items())
+        conditions = []
+        for k, v in kwargs:
+            if k.endswith('Date'):
+                condition = "{0} eq datetime'{1}'".format(k, v)
+            else:
+                condition = "{0} eq '{1}'".format(k, v)
+            conditions.append(condition)
+        params = ' and '.join(conditions)
         return self.endpoint("/events/?$filter={0}", params)
 
     def _scrapeWebCalendar(self):

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -248,6 +248,15 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
                 if web_key == api_key:
                     return event
 
+    def endpoint(self, route, *args) :
+        url = self.BASE_URL + route
+        response = self.get(url.format(*args))
+        return response.json()
+
+    def search(self, **kwargs):
+        params = ' and '.join("{0} eq '{1}'".format(k, v) for k, v in kwargs.items())
+        return self.endpoint("/events/?$filter={0}", params)
+
     def _scrapeWebCalendar(self):
         '''Generator yielding events from Legistar in roughly reverse
         chronological order.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-mock
 pytest
-icalendar

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,12 @@ setup(name='legistar',
       platforms=['any'],
       dependency_links = ['git+ssh://git@github.com/opencivicdata/pupa.git'],
       install_requires=[
+          'requests',
           'lxml',
           'pytz',
-          'icalendar'
+          'icalendar',
+          'scrapelib',
+          'pupa',
       ],
       classifiers=["Development Status :: 4 - Beta",
                    "Intended Audience :: Developers",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from legistar import base
+
+@pytest.fixture(scope="module")
+def scraper():
+    scraper = base.LegistarAPIScraper(None, None)
+    scraper.BASE_URL = 'http://webapi.legistar.com/v1/chicago'
+    scraper.retry_attempts = 0
+    scraper.requests_per_minute = 0
+    return scraper
+
+

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,27 +1,27 @@
-import unittest
-
 import pytest
 
 from legistar import base
 
+@pytest.fixture(scope="module")
+def scraper():
+    scraper = base.LegistarAPIScraper(None, None)
+    scraper.BASE_URL = 'http://webapi.legistar.com/v1/chicago'
+    scraper.retry_attempts = 0
+    scraper.requests_per_minute = 0
+    return scraper
 
-class TestAPISearch(unittest.TestCase):
 
-    def setUp(self):
-        self.scraper = base.LegistarAPIScraper(None, None)
-        self.scraper.BASE_URL = 'http://webapi.legistar.com/v1/chicago'
-        self.scraper.retry_attempts = 0
-        self.scraper.requests_per_minute = 0
-        
-    def test_search_raises(self):
+class TestAPISearch(object):
+
+    def test_search_raises(self, scraper):
         with pytest.raises(ValueError):
-            results = self.scraper.search('/events/', 'EventId',
-                                          "MatterFile eq 'O2010-5046'")
+            results = scraper.search('/events/', 'EventId',
+                                     "MatterFile eq 'O2010-5046'")
             list(results)
             
-    def test_search(self):
-        results = self.scraper.search('/matters/', 'MatterId',
-                                      "MatterFile eq 'O2010-5046'")
+    def test_search(self, scraper):
+        results = scraper.search('/matters/', 'MatterId',
+                                 "MatterFile eq 'O2010-5046'")
         
         
         assert len(list(results)) == 1

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,15 +2,6 @@ import pytest
 
 from legistar import base
 
-@pytest.fixture(scope="module")
-def scraper():
-    scraper = base.LegistarAPIScraper(None, None)
-    scraper.BASE_URL = 'http://webapi.legistar.com/v1/chicago'
-    scraper.retry_attempts = 0
-    scraper.requests_per_minute = 0
-    return scraper
-
-
 class TestAPISearch(object):
 
     def test_search_raises(self, scraper):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,27 @@
+import unittest
+
+import pytest
+
+from legistar import base
+
+
+class TestAPISearch(unittest.TestCase):
+
+    def setUp(self):
+        self.scraper = base.LegistarAPIScraper(None, None)
+        self.scraper.BASE_URL = 'http://webapi.legistar.com/v1/chicago'
+        self.scraper.retry_attempts = 0
+        self.scraper.requests_per_minute = 0
+        
+    def test_search_raises(self):
+        with pytest.raises(ValueError):
+            results = self.scraper.search('/events/', 'EventId',
+                                          "MatterFile eq 'O2010-5046'")
+            list(results)
+            
+    def test_search(self):
+        results = self.scraper.search('/matters/', 'MatterId',
+                                      "MatterFile eq 'O2010-5046'")
+        
+        
+        assert len(list(results)) == 1


### PR DESCRIPTION
Related to https://github.com/datamade/la-metro-councilmatic/issues/263, adds a method to search the Events API. 

### TO DO
- Move `endpoint` to the base `LegistarAPIScraper` class. (This is also a step toward #59.)
  - How do I handle `partialmethod`s in bills scraper, if `endpoint` is not defined in-file? https://github.com/opencivicdata/python-legistar-scraper/blob/63d47af162d0cd2a02ecd2e150825ec75b0c6d61/legistar/bills.py#L259-L260