### PR TITLE
Define event_url prior to referencing it

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -167,7 +167,8 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
                         yield api_event, web_event
 
                     else:
-                        self.warning('API event could not be found in web interface: {0}{1}'.format(events_url, api_event['EventId']))
+                        event_url = '{0}/events/{1}'.format(self.BASE_URL, api_event['EventId'])
+                        self.warning('API event could not be found in web interface: {0}'.format(event_url))
                         continue
 
     def api_events(self, since_datetime=None):


### PR DESCRIPTION
We lost the definition of `events_url` when we broke out `api_events`. This defines an `event_url` in the case where we can't find an event in the web interface, squashing https://sentry.io/datamade/scrapers-us-municipal/issues/531815553/