### PR TITLE
suppress leg items references in agenda items when appropriate,

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -13,7 +13,7 @@ import lxml.etree as etree
 import pytz
 
 
-class LegistarSession(requests.Session):
+class LegistarSession(object):
 
     def request(self, method, url, **kwargs):
         response = super(LegistarSession, self).request(method, url, **kwargs)
@@ -68,7 +68,7 @@ class LegistarSession(requests.Session):
         return all_range
 
 
-class LegistarScraper(scrapelib.Scraper, LegistarSession):
+class LegistarScraper(LegistarSession, scrapelib.Scraper):
     date_format = '%m/%d/%Y'
 
     def __init__(self, *args, **kwargs):

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -230,19 +230,14 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
 
         This is also practical because matter files that are hidden
         in the Legistar Agenda do not seem to available for scraping
-        on Legistar or through the API'''
+        on Legistar or through the API
 
-        if item['EventItemMatterFile'] is not None:
-
-            if item['EventItemMatterStatus'] == 'Draft':
-                suppress = True
-            elif item['EventItemMatterType'] == 'Closed Session':
-                suppress = True
-            else:
-                suppress = False
-
-            if suppress:
-                item['EventItemMatterFile'] = None
+        Since we are not completely sure that the same suppression
+        logic should be used for all Legislative Bodies, this method
+        is currently just a hook for being overridden in particular
+        scrapers. As of now, at least LA Metro uses this hook.
+        '''
+        pass
 
     def rollcalls(self, event):
         for item in self.agenda(event):

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -217,7 +217,32 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
                                      if item['EventItemTitle'])
 
         for item in filtered_response:
+            self._suppress_item_matter(item, agenda_url)
             yield item
+
+    def _suppress_item_matter(self, item, agenda_url):
+        '''
+        Agenda items in Legistar do not always display links to
+        associated matter files even if the same agenda item
+        in the API references a Matter File. The agenda items
+        we scrape should honor the suppression on the Legistar
+        agendas.
+
+        This is also practical because matter files that are hidden
+        in the Legistar Agenda do not seem to available for scraping
+        on Legistar or through the API'''
+
+        if item['EventItemMatterFile'] is not None:
+
+            if item['EventItemMatterStatus'] == 'Draft':
+                suppress = True
+            elif item['EventItemMatterType'] == 'Closed Session':
+                suppress = True
+            else:
+                suppress = False
+
+            if suppress:
+                item['EventItemMatterFile'] = None
 
     def rollcalls(self, event):
         for item in self.agenda(event):


### PR DESCRIPTION
Agenda items in Legistar do not always display links to associated matter files even if the same agenda item in the API references a Matter File. The agenda items we scrape should honor the suppression on the Legistar agendas.

This is also practical because matter files that are hidden in the Legistar Agenda do not seem to available for scraping on Legistar or through the API

closes https://github.com/opencivicdata/scrapers-us-municipal/issues/222