### PR TITLE
split agendas and minutes

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -212,7 +212,7 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
 
     def minutes(self, event):
         minutes_url = (self.BASE_URL +
-                      '/events/{}/eventitems'.format(event['EventId']))
+                       '/events/{}/eventitems'.format(event['EventId']))
 
         response = self.get(minutes_url)
 


### PR DESCRIPTION
In the API, eventitems combines both agenda items and items from the minutes. This makes some sense because often these items are the same. 

However, agendas and minutes are conceptually different things even if composed, in part, of the same substance and we should distinguish the two.

Since this is pretty big change, I'd like us to test this out locally.

Note that minute items are included in the eventitems even if the minutes are in draft, so right now we sometimes include items that are not intended to be published.