### PR TITLE
Scrape private

### DIFF
--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -214,7 +214,7 @@ def dateBound(creation_date):
 
 
 class LegistarAPIBillScraper(LegistarAPIScraper):
-    def matters(self, since_datetime=None, scrape_private=False):
+    def matters(self, since_datetime=None, scrape_restricted=False):
 
         # scrape from oldest to newest. This makes resuming big
         # scraping jobs easier because upon a scrape failure we can
@@ -235,7 +235,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             except KeyError:
                 url = matters_url + '/{}'.format(matter['MatterId'])
                 self.warning('Bill could not be found in web interface: {}'.format(url))
-                if scrape_private:
+                if scrape_restricted:
                     yield matter
                 else:
                     continue
@@ -244,7 +244,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
 
             yield matter
 
-    def matter(self, matter_id, scrape_private=False):
+    def matter(self, matter_id, scrape_restricted=False):
         matter = self.endpoint('/matters/{}', matter_id)
 
         try:
@@ -252,7 +252,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         except KeyError:
             url = self.BASE_URL + '/matters/{}'.format(matter_id)
             self.warning('Bill could not be found in web interface: {}'.format(url))
-            if scrape_private:
+            if scrape_restricted:
                 return matter
             else:   
                 return None

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -254,7 +254,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             self.warning('Bill could not be found in web interface: {}'.format(url))
             if scrape_restricted:
                 return matter
-            else:   
+            else:
                 return None
         else:
             matter['legistar_url'] = legistar_url

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -214,8 +214,7 @@ def dateBound(creation_date):
 
 
 class LegistarAPIBillScraper(LegistarAPIScraper):
-    # Make parameter optional, as it is in events.py
-    def matters(self, since_datetime=None):
+    def matters(self, since_datetime=None, scrape_private=False):
 
         # scrape from oldest to newest. This makes resuming big
         # scraping jobs easier because upon a scrape failure we can
@@ -236,13 +235,16 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             except KeyError:
                 url = matters_url + '/{}'.format(matter['MatterId'])
                 self.warning('Bill could not be found in web interface: {}'.format(url))
-                continue
+                if scrape_private:
+                    yield matter
+                else:
+                    continue
             else:
                 matter['legistar_url'] = legistar_url
 
             yield matter
 
-    def matter(self, matter_id):
+    def matter(self, matter_id, scrape_private=False):
         matter = self.endpoint('/matters/{}', matter_id)
 
         try:
@@ -250,7 +252,10 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         except KeyError:
             url = self.BASE_URL + '/matters/{}'.format(matter_id)
             self.warning('Bill could not be found in web interface: {}'.format(url))
-            return None
+            if scrape_private:
+                return matter
+            else:   
+                return None
         else:
             matter['legistar_url'] = legistar_url
 

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -216,9 +216,9 @@ def dateBound(creation_date):
 class LegistarAPIBillScraper(LegistarAPIScraper):
     def __init__(self, *args, **kwargs):
         '''
-        Initialize the Bill scraper with a `scrape_restricted` property. 
-        Do not collect private bills (i.e., bills with 'MatterRestrictViewViaWeb' 
-        set as True in the API), unless the scrapers have access to them, e.g., via a token. 
+        Initialize the Bill scraper with a `scrape_restricted` property.
+        Do not collect private bills (i.e., bills with 'MatterRestrictViewViaWeb'
+        set as True in the API), unless the scrapers have access to them, e.g., via a token.
         '''
         super().__init__(*args, **kwargs)
 

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -215,7 +215,6 @@ def dateBound(creation_date):
 
 class LegistarAPIBillScraper(LegistarAPIScraper):
     def matters(self, since_datetime=None, scrape_restricted=False):
-
         # scrape from oldest to newest. This makes resuming big
         # scraping jobs easier because upon a scrape failure we can
         # import everything scraped and then scrape everything newer
@@ -236,6 +235,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
                 url = matters_url + '/{}'.format(matter['MatterId'])
                 self.warning('Bill could not be found in web interface: {}'.format(url))
                 if scrape_restricted:
+                    matter['legistar_url'] = self.BASE_WEB_URL
                     yield matter
                 else:
                     continue
@@ -253,6 +253,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             url = self.BASE_URL + '/matters/{}'.format(matter_id)
             self.warning('Bill could not be found in web interface: {}'.format(url))
             if scrape_restricted:
+                matter['legistar_url'] = self.BASE_WEB_URL
                 return matter
             else:
                 return None

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -214,7 +214,7 @@ def dateBound(creation_date):
 
 
 class LegistarAPIBillScraper(LegistarAPIScraper):
-    def matters(self, since_datetime=None, scrape_restricted=False):
+    def matters(self, since_datetime=None):
         # scrape from oldest to newest. This makes resuming big
         # scraping jobs easier because upon a scrape failure we can
         # import everything scraped and then scrape everything newer
@@ -234,7 +234,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             except KeyError:
                 url = matters_url + '/{}'.format(matter['MatterId'])
                 self.warning('Bill could not be found in web interface: {}'.format(url))
-                if scrape_restricted:
+                if hasattr(self, 'scrape_restricted'):
                     matter['legistar_url'] = self.BASE_WEB_URL
                     yield matter
                 else:
@@ -244,7 +244,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
 
             yield matter
 
-    def matter(self, matter_id, scrape_restricted=False):
+    def matter(self, matter_id):
         matter = self.endpoint('/matters/{}', matter_id)
 
         try:
@@ -252,7 +252,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         except KeyError:
             url = self.BASE_URL + '/matters/{}'.format(matter_id)
             self.warning('Bill could not be found in web interface: {}'.format(url))
-            if scrape_restricted:
+            if hasattr(self, 'scrape_restricted'):
                 matter['legistar_url'] = self.BASE_WEB_URL
                 return matter
             else:

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -214,6 +214,16 @@ def dateBound(creation_date):
 
 
 class LegistarAPIBillScraper(LegistarAPIScraper):
+    def __init__(self, *args, **kwargs):
+        '''
+        Initialize the Bill scraper with a `scrape_restricted` property. 
+        Do not collect private bills (i.e., bills with 'MatterRestrictViewViaWeb' 
+        set as True in the API), unless the scrapers have access to them, e.g., via a token. 
+        '''
+        super().__init__(*args, **kwargs)
+
+        self.scrape_restricted = False
+
     def matters(self, since_datetime=None):
         # scrape from oldest to newest. This makes resuming big
         # scraping jobs easier because upon a scrape failure we can
@@ -234,10 +244,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             except KeyError:
                 url = matters_url + '/{}'.format(matter['MatterId'])
                 self.warning('Bill could not be found in web interface: {}'.format(url))
-                if hasattr(self, 'scrape_restricted'):
-                    matter['legistar_url'] = self.BASE_WEB_URL
-                    yield matter
-                else:
+                if not self.scrape_restricted:
                     continue
             else:
                 matter['legistar_url'] = legistar_url
@@ -252,10 +259,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         except KeyError:
             url = self.BASE_URL + '/matters/{}'.format(matter_id)
             self.warning('Bill could not be found in web interface: {}'.format(url))
-            if hasattr(self, 'scrape_restricted'):
-                matter['legistar_url'] = self.BASE_WEB_URL
-                return matter
-            else:
+            if not self.scrape_restricted:
                 return None
         else:
             matter['legistar_url'] = legistar_url


### PR DESCRIPTION
This PR enables scraping private bills.

It works in cooperation with the changes in https://github.com/opencivicdata/scrapers-us-municipal/pull/258.