### PR TITLE
Text with version arg

### DIFF
--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -351,24 +351,25 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
 
     def text(self, matter_id, latest_version_value=None):
         '''Historically, we have determined the latest version of a bill
-        by finding the version with the highest value (either numerical or otherwise).
-        
-        However, the `MatterVersion` field on the matter detail page 
-        most accurately identifies the latest version of a bill. 
+        by finding the version with the highest value (either numerical or alphabetical).
+
+        However, the `MatterVersion` field on the matter detail page
+        most accurately identifies the latest version of a bill.
         This proves to be true for Metro, in particular.
+
         Other municipalities may share this characteristic with Metro.
         Until we know more, the `text` function accepts `latest_version_value`,
-        i.e., matter['MatterVersion'], as an optional argument.  
-        '''
+        i.e., matter['MatterVersion'], as an optional argument.'''
+
         version_route = '/matters/{0}/versions'
         text_route = '/matters/{0}/texts/{1}'
 
         versions = self.endpoint(version_route, matter_id)
 
-        if latest_version_value: 
+        if latest_version_value:
             latest_version = next(
-                version for version 
-                in versions 
+                version for version
+                in versions
                 if version['Value'] == latest_version_value)
         else:
             latest_version = max(

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -352,24 +352,24 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
     def text(self, matter_id, latest_version_value=None):
         '''Historically, we have determined the latest version of a bill
         by finding the version with the highest value (either numerical or otherwise).
-        
-        However, the `MatterVersion` field on the matter detail page 
-        most accurately identifies the latest version of a bill. 
+
+        However, the `MatterVersion` field on the matter detail page
+        most accurately identifies the latest version of a bill.
         This proves to be true for Metro, in particular.
 
         Other municipalities may share this characteristic with Metro.
         Until we know more, the `text` function accepts `latest_version_value`,
-        i.e., matter['MatterVersion'], as an optional argument.  
+        i.e., matter['MatterVersion'], as an optional argument.
         '''
         version_route = '/matters/{0}/versions'
         text_route = '/matters/{0}/texts/{1}'
 
         versions = self.endpoint(version_route, matter_id)
 
-        if latest_version_value: 
+        if latest_version_value:
             latest_version = next(
-                version for version 
-                in versions 
+                version for version
+                in versions
                 if version['Value'] == latest_version_value)
         else:
             latest_version = max(

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -349,14 +349,31 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         else:
             return []
 
-    def text(self, matter_id):
+    def text(self, matter_id, latest_version_value=None):
+        '''Historically, we have determined the latest version of a bill
+        by finding the version with the highest value (either numerical or otherwise).
+        
+        However, the `MatterVersion` field on the matter detail page 
+        most accurately identifies the latest version of a bill. 
+        This proves to be true for Metro, in particular.
+
+        Other municipalities may share this characteristic with Metro.
+        Until we know more, the `text` function accepts `latest_version_value`,
+        i.e., matter['MatterVersion'], as an optional argument.  
+        '''
         version_route = '/matters/{0}/versions'
         text_route = '/matters/{0}/texts/{1}'
 
         versions = self.endpoint(version_route, matter_id)
 
-        latest_version = max(
-            versions, key=lambda x: self._version_rank(x['Value']))
+        if latest_version_value: 
+            latest_version = next(
+                version for version 
+                in versions 
+                if version['Value'] == latest_version_value)
+        else:
+            latest_version = max(
+                versions, key=lambda x: self._version_rank(x['Value']))
 
         text_url = self.BASE_URL + \
             text_route.format(matter_id, latest_version['Key'])


### PR DESCRIPTION
This PR modifies the `text` function in the `APIBillScraper`: the function now enables discovery of the most current bill version via the `MatterVersion` field in the API. I included a fairly verbose explanatory doc string, but that verbiage could easier be condensed and/or moved to an issue. 

This PR relates to https://github.com/datamade/la-metro-councilmatic/issues/237