### PR TITLE
we want to retry transient problems with head requests

### DIFF
--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -2,7 +2,6 @@ from .base import LegistarScraper, LegistarAPIScraper
 from lxml.etree import tostring
 from collections import deque
 from functools import partialmethod
-import requests
 from urllib.parse import urljoin
 
 
@@ -384,7 +383,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
     def legislation_detail_url(self, matter_id):
         gateway_url = self.BASE_WEB_URL + '/gateway.aspx?m=l&id={0}'
 
-        legislation_detail_route = requests.head(
+        legislation_detail_route = self.head(
             gateway_url.format(matter_id)).headers['Location']
 
         return urljoin(self.BASE_WEB_URL, legislation_detail_route)


### PR DESCRIPTION
For reasons that are obscure, and which may not be existent, at some point we stopped using the scrapers class's own `head` method for getting the bill detail url, and instead used the methods from the requests library.

A consequence of this is that if there was an error when we made the head request, we wouldn't retry it.  But, we would like to retry it. So we are reverting. 

I've tested this locally a bunch of times, but was not able to trigger an error to retry. 