### PR TITLE
suppress session level params in head request

### DIFF
--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -383,8 +383,11 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
     def legislation_detail_url(self, matter_id):
         gateway_url = self.BASE_WEB_URL + '/gateway.aspx?m=l&id={0}'
 
+        # we want to supress any session level params for this head request
+        # since they could lead to an additonal level of redirect
         legislation_detail_route = self.head(
-            gateway_url.format(matter_id)).headers['Location']
+            gateway_url.format(matter_id),
+            params={k: None for k in self.params}).headers['Location']
 
         return urljoin(self.BASE_WEB_URL, legislation_detail_route)
 

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -384,7 +384,11 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         gateway_url = self.BASE_WEB_URL + '/gateway.aspx?m=l&id={0}'
 
         # we want to supress any session level params for this head request
-        # since they could lead to an additonal level of redirect
+        # since they could lead to an additonal level of redirect.
+        #
+        # Per
+        # http://docs.python-requests.org/en/master/user/advanced/, we
+        # have to do this by setting session level params to None
         legislation_detail_route = self.head(
             gateway_url.format(matter_id),
             params={k: None for k in self.params}).headers['Location']


### PR DESCRIPTION
This PR removes any session level params from the head request we use to get the web url for a matter. This is particularly important for scrapers where we use a secret token to access the API.