### PR TITLE
Retry on legistar sesion errors

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -13,7 +13,7 @@ import lxml.etree as etree
 import pytz
 
 
-class LegistarSession(object):
+class LegistarSession(requests.Session):
 
     def request(self, method, url, **kwargs):
         response = super(LegistarSession, self).request(method, url, **kwargs)
@@ -68,7 +68,7 @@ class LegistarSession(object):
         return all_range
 
 
-class LegistarScraper(LegistarSession, scrapelib.Scraper):
+class LegistarScraper(scrapelib.Scraper, LegistarSession):
     date_format = '%m/%d/%Y'
 
     def __init__(self, *args, **kwargs):

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -283,7 +283,8 @@ class LegistarAPIEventScraper(LegistarAPIScraper):
         chronological order.
         '''
         web_scraper = LegistarEventsScraper(
-            requests_per_minute=self.requests_per_minute)
+            requests_per_minute=self.requests_per_minute,
+            retry_attempts=self.retry_attempts)
 
         if self.cache_storage:
             web_scraper.cache_storage = self.cache_storage


### PR DESCRIPTION
This PR fixes the method resolution error and sets the retries for the event webscraper to mirror the pupa retries. 

This has the consequence of allowing the event scraper to retry on some sorts of transient errors when scraping the web.