### PR TITLE
only raise a 520 for empty content on get and post requests

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -29,8 +29,9 @@ class LegistarSession(requests.Session):
             raise scrapelib.HTTPError(response)
 
         if not response.text:
-            response.status_code = 520
-            raise scrapelib.HTTPError(response)
+            if response.request.method.lower() in {'get', 'post'}:
+                response.status_code = 520
+                raise scrapelib.HTTPError(response)
 
         if payload:
             self._range_error(response, payload)


### PR DESCRIPTION
Head requests, for example, almost always have empty bodies.