### PR TITLE
Don't try to pull from cache for top level events page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "3.5"
 install:
   - pip install -r requirements.txt
   - pip install -e .

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -6,12 +6,18 @@ import lxml.html
 import pytz
 import icalendar
 
-from .base import LegistarScraper, LegistarAPIScraper
+from .base import LegistarScraper, LegistarAPIScraper, LegistarSession
 
 
 class LegistarEventsScraper(LegistarScraper):
     def eventPages(self, since):
-        response = self.get(self.EVENTSPAGE, verify=False)
+
+        # We are using the LegistarSession instead of the self.lxmlize
+        # and or self.get methods because we need to be sure that we
+        # get the first page directly from InSite and not from a cache
+        # in order that we have a valid ASP secrets
+        session = LegistarSession()
+        response = session.get(self.EVENTSPAGE)
         entry = response.text
         page = lxml.html.fromstring(entry)
         page.make_links_absolute(self.EVENTSPAGE)

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -18,12 +18,18 @@ class LegistarEventsScraper(LegistarScraper):
     def should_cache_response(self, response):
         # Never cache the top level events page, because that may result in
         # expired .NET state values.
+        #
+        # works in concert with `key_for_request` to stop a request
+        # from using the cache
         return (super().should_cache_response(response) and
                 response.url != self.EVENTSPAGE)
 
     def key_for_request(self, method, url, **kwargs):
         # avoid attempting to pull top level events page from cache by
         # making sure the key for that page is None
+        #
+        # works in concert with `should_cache_response` to stop a request
+        # from using the cache
         if url == self.EVENTSPAGE:
             return None
 

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -2,11 +2,10 @@ import time
 import datetime
 from collections import deque
 
-import lxml.html
 import pytz
 import icalendar
 
-from .base import LegistarScraper, LegistarAPIScraper, LegistarSession
+from .base import LegistarScraper, LegistarAPIScraper
 
 
 class LegistarEventsScraper(LegistarScraper):
@@ -22,7 +21,7 @@ class LegistarEventsScraper(LegistarScraper):
         return (super().should_cache_response(response) and
                 response.url != self.EVENTSPAGE)
 
-    def key_for_request(method, url, **kwargs):
+    def key_for_request(self, method, url, **kwargs):
         # avoid attempting to pull top level events page from cache by
         # making sure the key for that page is None
         if url == self.EVENTSPAGE:


### PR DESCRIPTION
Previously, we created a method on the LegistarEvents page to prevent the caching of the top level events page. #86. 

However, we didn't make a method for preventing pull from the cache if that page had already been cached. This adds that.