### PR TITLE
Don't break from web scrape if there are not yet future events

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -89,7 +89,10 @@ class LegistarEventsScraper(LegistarScraper):
                     yield event, agenda
                     no_events_in_year = False
 
-            if no_events_in_year:  # Bail from scrape if no results returned from year
+            # Bail from scrape if no results returned from year, _unless_ it's
+            # next year, as there may not be events scheduled that far into
+            # the future.
+            if no_events_in_year and year <= current_year:
                 break
 
     def agenda(self, detail_url):


### PR DESCRIPTION
Our events web scraper stops scraping if it does not find events in a given year, but it also starts looking for events one year into the future. If events are not scheduled that far into the future, the web scrape will exit prematurely, leading to behavior like https://github.com/opencivicdata/scrapers-us-municipal/pull/290#discussion_r337758528.

This PR patches the logic hole, allowing for there to be no future events without exiting the scrape.