### PR TITLE
Make time string format configurable, handle bad start times

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -264,6 +264,7 @@ def fieldKey(x):
 
 class LegistarAPIScraper(scrapelib.Scraper):
     date_format = '%Y-%m-%dT%H:%M:%S'
+    time_string_format = '%I:%M %p'
     utc_timestamp_format = '%Y-%m-%dT%H:%M:%S.%f'
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
On Friday, our event scrapes were interrupted because one event had an invalid start date. This PR handles invalid start times. Since start times are entered manually, it also makes the time string format configurable, so the scraper can be used for jurisdictions who use a different time format.

Closes https://github.com/opencivicdata/scrapers-us-municipal/issues/310.