### PR TITLE
Don't read from the cache when scraping fast, but not in fast mode

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -158,8 +158,7 @@ class LegistarAPIEventScraperBase(LegistarAPIScraper, metaclass=ABCMeta):
         if self.cache_storage:
             webscraper.cache_storage = self.cache_storage
 
-        if self.requests_per_minute == 0:
-            webscraper.cache_write_only = False
+        webscraper.cache_write_only = self.cache_write_only
 
         webscraper.BASE_URL = self.WEB_URL
 


### PR DESCRIPTION
## Description

This PR sets `cache_read_only` using the same attribute from the API scraper, instead of trying to infer it from requests per minute. This patches a bug where fast event scrapes always read from the cache. https://github.com/datamade/scrapers-us-municipal/issues/44
