### PR TITLE
Grab eComment link mapping from meetings.js

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -264,6 +264,7 @@ def fieldKey(x):
 
 class LegistarAPIScraper(scrapelib.Scraper):
     date_format = '%Y-%m-%dT%H:%M:%S'
+    time_string_format = '%I:%M %p'
     utc_timestamp_format = '%Y-%m-%dT%H:%M:%S.%f'
 
     def __init__(self, *args, **kwargs):

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -124,7 +124,8 @@ class LegistarScraper(scrapelib.Scraper, LegistarSession):
         Parse the data in the top section of a detail page.
         """
         detail_query = ".//*[starts-with(@id, 'ctl00_ContentPlaceHolder1_lbl')"\
-                       "     or starts-with(@id, 'ctl00_ContentPlaceHolder1_hyp')]"
+                       "     or starts-with(@id, 'ctl00_ContentPlaceHolder1_hyp')"\
+                       "     or starts-with(@id, 'ctl00_ContentPlaceHolder1_Label')]"
         fields = detail_div.xpath(detail_query)
         details = {}
 
@@ -256,7 +257,7 @@ class LegistarScraper(scrapelib.Scraper, LegistarSession):
 
 def fieldKey(x):
     field_id = x.attrib['id']
-    field = re.split(r'hyp|lbl', field_id)[-1]
+    field = re.split(r'hyp|lbl|Label', field_id)[-1]
     field = field.split('Prompt')[0]
     field = field.rstrip('X21')
     return field

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -79,32 +79,6 @@ class LegistarScraper(scrapelib.Scraper, LegistarSession):
     def __init__(self, *args, **kwargs):
         super(LegistarScraper, self).__init__(*args, **kwargs)
 
-    @property
-    def ecomment_dict(self):
-        """
-        Parse event IDs and eComment links from JavaScript file with lines like:
-        activateEcomment('750', '138A085F-0AC1-4A33-B2F3-AC3D6D9F710B', 'https://metro.granicusideas.com/meetings/750-finance-budget-and-audit-committee-on-2020-03-16-5-00-pm-test');
-        """
-        if not getattr(self, '_ecomment_dict', None):
-            ecomment_dict = {}
-
-            script = requests.get('https://metro.granicusideas.com/meetings.js')
-
-            lines = [line.strip() for line in script.text.splitlines()
-                     if line.strip().startswith('activateEcomment')]
-
-            for line in lines:
-                event_id, _, ecomment_url = line.split(',')
-
-                formatted_event_id = event_id.replace("'", '').replace('activateEcomment(', '').strip()
-                formatted_ecomment_url = ecomment_url.replace("'", '').replace(");", '').strip()
-
-                ecomment_dict[formatted_event_id] = formatted_ecomment_url
-
-            self._ecomment_dict = ecomment_dict
-
-        return self._ecomment_dict
-
     def lxmlize(self, url, payload=None):
         '''
         Gets page and returns as XML
@@ -153,23 +127,28 @@ class LegistarScraper(scrapelib.Scraper, LegistarSession):
                        "     or starts-with(@id, 'ctl00_ContentPlaceHolder1_hyp')"\
                        "     or starts-with(@id, 'ctl00_ContentPlaceHolder1_Label')]"
         fields = detail_div.xpath(detail_query)
+
         details = {}
 
-        for field_key, field in itertools.groupby(fields,
-                                                  fieldKey):
+        for field_key, field in itertools.groupby(fields, fieldKey):
             field = list(field)
             field_1, field_2 = field[0], field[-1]
+
             key = field_1.text_content().replace(':', '').strip()
+
             if field_2.find('.//a') is not None:
                 value = []
                 for link in field_2.xpath('.//a'):
                     value.append({'label': link.text_content().strip(),
                                   'url': self._get_link_address(link)})
-            elif key == 'eComment':
-                value = self._get_ecomment_link(field_2) or field_2.text_content().strip()
+
             elif 'href' in field_2.attrib:
                 value = {'label': field_2.text_content().strip(),
                          'url': self._get_link_address(field_2)}
+
+            elif self._parse_detail(key, field_1, field_2):
+                value = self._parse_detail(key, field_1, field_2)
+
             else:
                 value = field_2.text_content().strip()
 
@@ -245,9 +224,12 @@ class LegistarScraper(scrapelib.Scraper, LegistarSession):
 
         return url
 
-    def _get_ecomment_link(self, link):
-        event_id = link.attrib['data-event-id']
-        return self.ecomment_dict.get(event_id, None)
+    def _parse_detail(self, key, field_1, field_2):
+        """
+        Perform custom parsing on a given key and field from a detail table.
+        Available for override on web scraper base classes.
+        """
+        return None
 
     def _stringify(self, field):
         for br in field.xpath("*//br"):

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -158,8 +158,7 @@ class LegistarAPIEventScraperBase(LegistarAPIScraper, metaclass=ABCMeta):
         if self.cache_storage:
             webscraper.cache_storage = self.cache_storage
 
-        if self.requests_per_minute == 0:
-            webscraper.cache_write_only = False
+        webscraper.cache_write_only = self.cache_write_only
 
         webscraper.BASE_URL = self.WEB_URL
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='legistar',
                         'pytz',
                         'icalendar',
                         'scrapelib',
+                        'esprima'
                         ],
       classifiers=["Development Status :: 4 - Beta",
                    "Intended Audience :: Developers",


### PR DESCRIPTION
### Description

eComment links are rendered by a JavaScript event, which is a pain for us, because we can't scrape them.

This PR spikes one method of mapping events to their eComment links by creating a lookup table from the JavaScript file located at [`https://metro.granicusideas.com/meetings.js`](https://metro.granicusideas.com/meetings.js).

This file is loaded on both the [event listing page](https://metro.legistar.com/Calendar.aspx), and [event detail](https://metro.legistar.com/MeetingDetail.aspx?LEGID=1718&GID=557&G=A5FAA737-A54D-4A6C-B1E8-FF70F765FA94) pages. I do not see any evidence on either page that it's filterable, e.g., shows only eComments links for visible events on a listing page. I have also confirmed that, when multiple eComment pages are enabled, they all show up in this JavaScript file.

### Alternatives

eComment links look like `https://metro.granicusideas.com/meetings/750-finance-budget-and-audit-committee-on-2020-03-16-5-00-pm-test`. One alternative I considered is proposing a standard format for eComment titles (if they are in fact editable by Metro) and programmatically building the slug for the URL.

It looks like the meeting ID is automatically prepended (?), so we'd still need to parse that from the detail table, but the slug generation should happen on the event scraper, instead of on the base class, since it requires event details.

I decided to prefer the JavaScript approach, because relying on manual data entry in the past has caused us some big headaches. If the proposed approach does not work as I think it does, then this could be a feasible fallback.

### Notes

It would be better code organization to define these changes on the event scraper, but it also feels coupled tightly enough to detail table parsing that it can live on the base class. I [spiked moving it to the event scraper](https://github.com/opencivicdata/python-legistar-scraper/compare/feature/hec/scrape-ecomment-link...spike/hec/move-comments-to-event), but we lose some of the niceness of our API event scraping separation. Happy for your feedback here.