### PR TITLE
add dates to consider in search windows for bills and events

### DIFF
--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -232,6 +232,8 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         params = {'$orderby': 'MatterLastModifiedUtc'}
 
         if since_datetime:
+            since_iso = since_datetime.isoformat()
+
             update_fields = ('MatterLastModifiedUtc',
                              'MatterIntroDate',
                              'MatterPassedDate',
@@ -253,8 +255,10 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
                              'MatterAgendaDate')
 
             since_fmt = "{field} gt datetime'{since_datetime}'"
-            since_filter = ' or '.join(since_fmt.format(field=field, since_datetime=since_datetime.isoformat())
-                                       for field in update_fields)
+            since_filter =\
+                ' or '.join(since_fmt.format(field=field,
+                                             since_datetime=since_iso)
+                            for field in update_fields)
 
             params['$filter'] = since_filter
 

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -232,7 +232,31 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         params = {'$orderby': 'MatterLastModifiedUtc'}
 
         if since_datetime:
-            params['$filter'] = "MatterLastModifiedUtc gt datetime'{since_datetime}'".format(since_datetime=since_datetime.isoformat())
+            update_fields = ('MatterLastModifiedUtc',
+                             'MatterIntroDate',
+                             'MatterPassedDate',
+                             'MatterDate1',
+                             'MatterDate2',
+                             # 'MatterEXDate1', # can't use all 17 search
+                                                # terms, this one always
+                                                # seems to be not set
+                             'MatterEXDate2',
+                             'MatterEXDate3',
+                             'MatterEXDate4',
+                             'MatterEXDate5',
+                             'MatterEXDate6',
+                             'MatterEXDate7',
+                             'MatterEXDate8',
+                             'MatterEXDate9',
+                             'MatterEXDate10',
+                             'MatterEnactmentDate',
+                             'MatterAgendaDate')
+
+            since_fmt = " gt datetime'{}'".format(since_datetime.isoformat())
+            since_filter = ' or '.join(field + since_fmt
+                                       for field in update_fields)
+
+            params['$filter'] = since_filter
 
         matters_url = self.BASE_URL + '/matters'
 

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -252,8 +252,8 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
                              'MatterEnactmentDate',
                              'MatterAgendaDate')
 
-            since_fmt = " gt datetime'{}'".format(since_datetime.isoformat())
-            since_filter = ' or '.join(field + since_fmt
+            since_fmt = "{field} gt datetime'{since_datetime}'"
+            since_filter = ' or '.join(since_fmt.format(field=field, since_datetime=since_datetime.isoformat())
                                        for field in update_fields)
 
             params['$filter'] = since_filter

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -218,7 +218,9 @@ class LegistarAPIEventScraperBase(LegistarAPIScraper, metaclass=ABCMeta):
         params = {'$orderby': 'EventLastModifiedUtc'}
 
         if since_datetime:
-            # Minutes are often published after an event occurs – without a
+            since_iso = since_datetime.isoformat()
+
+            # Minutes are often published after an event occurs – without a
             # corresponding event modification. Query all update fields so later
             # changes are always caught by our scraper, particularly when
             # scraping narrower windows of time.
@@ -227,9 +229,11 @@ class LegistarAPIEventScraperBase(LegistarAPIScraper, metaclass=ABCMeta):
                              'EventAgendaLastPublishedUTC',
                              'EventMinutesLastPublishedUTC')
 
-            since_fmt = " gt datetime'{}'".format(since_datetime.isoformat())
-            since_filter = ' or '.join(field + since_fmt
-                                       for field in update_fields)
+            since_fmt = "{field} gt datetime'{since_datetime}'"
+            since_filter =\
+                ' or '.join(since_fmt.format(field=field,
+                                             since_datetime=since_iso)
+                            for field in update_fields)
 
             params['$filter'] = since_filter
 

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -222,12 +222,14 @@ class LegistarAPIEventScraperBase(LegistarAPIScraper, metaclass=ABCMeta):
             # corresponding event modification. Query all update fields so later
             # changes are always caught by our scraper, particularly when
             # scraping narrower windows of time.
-            update_fields = ('EventLastModifiedUtc',
+            update_fields = ('EventDate',
+                             'EventLastModifiedUtc',
                              'EventAgendaLastPublishedUTC',
                              'EventMinutesLastPublishedUTC')
 
             since_fmt = " gt datetime'{}'".format(since_datetime.isoformat())
-            since_filter = ' or '.join(field + since_fmt for field in update_fields)
+            since_filter = ' or '.join(field + since_fmt
+                                       for field in update_fields)
 
             params['$filter'] = since_filter
 


### PR DESCRIPTION
For events, this PR will include events scheduled after the beginning of the search window in windowed event scrapes.

For bills, the PR also adds a number of date values to consider in the search window.

closes #107 