### PR TITLE
Fail the scrape if a legislation detail URL returns an expected status code

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -24,7 +24,7 @@ class LegistarSession(requests.Session):
         return response
 
     def _check_errors(self, response, payload):
-        if response.url.endswith('Error.aspx') or 'gateway.aspx' in response.url:
+        if response.url.endswith('Error.aspx'):
             response.status_code = 503
             raise scrapelib.HTTPError(response)
 

--- a/legistar/base.py
+++ b/legistar/base.py
@@ -24,7 +24,7 @@ class LegistarSession(requests.Session):
         return response
 
     def _check_errors(self, response, payload):
-        if response.url.endswith('Error.aspx'):
+        if response.url.endswith('Error.aspx') or 'gateway.aspx' in response.url:
             response.status_code = 503
             raise scrapelib.HTTPError(response)
 

--- a/legistar/bills.py
+++ b/legistar/bills.py
@@ -4,6 +4,7 @@ from collections import deque
 from functools import partialmethod
 from urllib.parse import urljoin
 import requests
+import scrapelib
 
 
 class LegistarBillScraper(LegistarScraper):
@@ -270,7 +271,10 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             try:
                 legistar_url = self.legislation_detail_url(matter['MatterId'])
 
-            except KeyError:
+            except scrapelib.HTTPError as e:
+                if e.response.status_code > 403:
+                    raise
+
                 url = matters_url + '/{}'.format(matter['MatterId'])
                 self.warning('Bill could not be found in web interface: {}'.format(url))
                 if not self.scrape_restricted:
@@ -286,11 +290,15 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
 
         try:
             legistar_url = self.legislation_detail_url(matter_id)
-        except KeyError:
+        except scrapelib.HTTPError as e:
+            if e.response.status_code > 403:
+                raise
+
             url = self.BASE_URL + '/matters/{}'.format(matter_id)
             self.warning('Bill could not be found in web interface: {}'.format(url))
             if not self.scrape_restricted:
                 return None
+
         else:
             matter['legistar_url'] = legistar_url
 
@@ -450,7 +458,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             return response.json()
 
     def legislation_detail_url(self, matter_id):
-        gateway_url = self.BASE_WEB_URL + '/gateway.aspx?m=l&id={0}'
+        gateway_url = self.BASE_WEB_URL + '/gateway.aspx?m=l&id={0}'.format(matter_id)
 
         # We want to supress any session level params for this head request,
         # since they could lead to an additonal level of redirect.
@@ -459,7 +467,7 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         # http://docs.python-requests.org/en/master/user/advanced/, we
         # have to do this by setting session level params to None
         response = self.head(
-            gateway_url.format(matter_id),
+            gateway_url,
             params={k: None for k in self.params}
         )
 
@@ -469,13 +477,18 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
             legislation_detail_route = response.headers['Location']
             return urljoin(self.BASE_WEB_URL, legislation_detail_route)
 
-        # If the status code is anything but a 200 or 302, something is wrong.
-        # Raise an HTTPError to interrupt the scrape.
-        elif response.status_code != 200:
+        # If the gateway URL returns a 200, it has not redirected, i.e., the
+        # matter is not publicly viewable. Return an unauthorized response.
+        elif response.status_code == 200:
+            response.status_code = 403
             raise scrapelib.HTTPError(response)
 
-        # If the gateway URL returns a 200, it has not redirected, i.e., the
-        # matter is not publicly viewable. Return nothing.
+        # If the status code is anything but a 200 or 302, something is wrong.
+        # Raise an HTTPError to interrupt the scrape.
+        else:
+            self.error('{0} returned an unexpected status code: {1}'.format(gateway_url, response.status_code))
+            response.status_code = 500
+            raise scrapelib.HTTPError(response)
 
     def _missing_votes(self, response):
         '''
@@ -504,5 +517,6 @@ class LegistarAPIBillScraper(LegistarAPIScraper):
         error.
         '''
         accept = (super().accept_response(response) or
-                  self._missing_votes(response))
+                  self._missing_votes(response) or
+                  response.status_code <= 403)
         return accept


### PR DESCRIPTION
## Description

This PR updates the `legislation_detail_url` to check for 302 or 200 responses, and fail otherwise. It closes #110.

## Testing instructions

- If you don't have a local copy, clone the municipal scrapers: `git clone https://github.com/opencivicdata/scrapers-us-municipal.git`.
- Follow the start up instructions, then install your local version of `python-legistar-scraper`: `pip install -e /path/to/python-legistar-scraper`.
- Run a Metro bill scrape of a reasonable window (I chose 90 days), and confirm that it runs as expected: `pupa update lametro --scrape bills window=90 --rpm=0`. (This change should only affect the scrape if there is an outage.)