### PR TITLE
Bug/event details

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -17,12 +17,9 @@ class LegistarEventsScraper(LegistarScraper):
         'https://metro.granicusideas.com/meetings.js?scope=past'
     )
 
-    def __init__(self, *args, verbose_keys=True, **kwargs):
+    def __init__(self, *args, event_info_key='Meeting Details', **kwargs):
         super().__init__(*args, **kwargs)
-        if verbose_keys:
-            self.event_info_key = 'Meeting Details'
-        else:
-            self.event_info_key = 'Details'
+        self.event_info_key = event_info_key
 
 
     @property

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -17,9 +17,13 @@ class LegistarEventsScraper(LegistarScraper):
         'https://metro.granicusideas.com/meetings.js?scope=past'
     )
 
-    def __init__(self, *args, event_info_key='Meeting Details', **kwargs):
+    def __init__(self, *args, verbose_keys=True, **kwargs):
         super().__init__(*args, **kwargs)
-        self.event_info_key = event_info_key
+        if verbose_keys:
+            self.event_info_key = 'Meeting Details'
+        else:
+            self.event_info_key = 'Details'
+
 
     @property
     def ecomment_dict(self):

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -17,6 +17,10 @@ class LegistarEventsScraper(LegistarScraper):
         'https://metro.granicusideas.com/meetings.js?scope=past'
     )
 
+    def __init__(self, *args, event_info_key='Meeting Details', **kwargs):
+        super().__init__(*args, **kwargs)
+        self.event_info_key = event_info_key
+
     @property
     def ecomment_dict(self):
         """
@@ -111,8 +115,8 @@ class LegistarEventsScraper(LegistarScraper):
                     else:
                         scraped_events.append(ical_url)
 
-                    if follow_links and type(event["Meeting Details"]) == dict:
-                        agenda = self.agenda(event["Meeting Details"]['url'])
+                    if follow_links and type(event[self.event_info_key]) == dict:
+                        agenda = self.agenda(event[self.event_info_key]['url'])
                     else:
                         agenda = None
 


### PR DESCRIPTION
This PR updates logic in the `LegistarEventScraper` class to take keys for the `event` object that are different from those expected in the methods for that class. It introduces a `verbose_keys` flag that accounts for the differences in keys described in issue #115 .

## Testing
* Tested locally in conjunction with the civic-scraper [testing of 30 legistar sites](https://github.com/datamade/civic-scraper/pull/12)
    * update the requirements.txt file in the civic-scraper repo to point to this branch of python-legistar-scraper as well as pytest & re-install the requirements
    * comment out all but the [information about Phoenix's legistar instance](https://github.com/datamade/civic-scraper/pull/12/files#diff-d2311e66bb9315db40f24c522ccbcff30325840a1b4b8f4a2f6b7c14a15404d5R78-R82) in `tests/legistar_scraper.py`
    * test with `pytest -m tests.legistar_scraper`