### PR TITLE
Update search table xpath

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -108,7 +108,7 @@ class LegistarEventsScraper(LegistarScraper):
             no_events_in_year = True
 
             for page in self.eventPages(year):
-                events_table = page.xpath("//table[@class='rgMasterTable']")[0]
+                events_table = page.xpath("//div[@id='ctl00_ContentPlaceHolder1_MultiPageCalendar']//table[@class='rgMasterTable']")[0]
                 for event, _, _ in self.parseDataTable(events_table):
                     ical_url = event['iCalendar']['url']
                     if ical_url in scraped_events:


### PR DESCRIPTION
## Overview

This PR fixes a bug in where `LegistarEventsScraper.events()` returned zero events for certain sites.

## Notes

This bug occurred because some Legistar sites had two tables on their front page: an upcoming events table and a searchable table. The Legistar scraper assumed sites only contained the latter and was querying the first table it found on the site.

![FireShot Capture 006 - City of Fullerton - Calendar - fullerton legistar com](https://user-images.githubusercontent.com/36973363/176507075-30b3c692-9b99-4d08-a058-058c07d1967f.png)
