### PR TITLE
Update the call signature for key_for_request

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -61,7 +61,7 @@ class LegistarEventsScraper(LegistarScraper):
         return (super().should_cache_response(response) and
                 response.url != self.EVENTSPAGE)
 
-    def key_for_request(self, method, url, **kwargs):
+    def key_for_request(self, method, url, params):
         # avoid attempting to pull top level events page from cache by
         # making sure the key for that page is None
         #
@@ -70,7 +70,7 @@ class LegistarEventsScraper(LegistarScraper):
         if url == self.EVENTSPAGE:
             return None
 
-        return super().key_for_request(method, url, **kwargs)
+        return super().key_for_request(method, url, params)
 
     def eventSearch(self, page, since):
         payload = self.sessionSecrets(page)


### PR DESCRIPTION
## Description

This PR updates the `key_for_request` call to explicitly pass params, the only accepted upstream keyword argument, rather than using **kwargs. I'm not sure why, but the previous approach raises a TypeError:

```
Traceback (most recent call last):
  File "/usr/local/bin/pupa", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/pupa/cli/__main__.py", line 75, in main
    subcommands[args.subcommand].handle(args, other)
  File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 334, in handle
    return self.do_handle(args, other, juris)
  File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 391, in do_handle
    report["scrape"] = self.do_scrape(juris, args, scrapers)
  File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 215, in do_scrape
    report[scraper_name] = scraper.do_scrape(**scrape_args)
  File "/usr/local/lib/python3.10/site-packages/pupa/scrape/base.py", line 120, in do_scrape
    for obj in self.scrape(**kwargs) or []:
  File "/app/lametro/bills.py", line 204, in scrape
    for matter in matters:
  File "/app/lametro/bills.py", line 166, in matters
    for api_event, _ in event_scraper.events(since_datetime=since_datetime):
  File "/usr/local/lib/python3.10/site-packages/legistar/events.py", line 278, in events
    web_event = self._get_web_event(api_event)
  File "/usr/local/lib/python3.10/site-packages/legistar/events.py", line 381, in _get_web_event
    return self.web_detail(api_event)
  File "/usr/local/lib/python3.10/site-packages/legistar/events.py", line 391, in web_detail
event_page = self._webscraper.lxmlize(insite_url)
  File "/usr/local/lib/python3.10/site-packages/legistar/base.py", line 89, in lxmlize
    response = self.get(url, verify=False)
  File "/usr/local/lib/python3.10/site-packages/requests/sessions.py", line 600, in get
    return self.request("GET", url, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/scrapelib/__init__.py", line 574, in request
    resp = super().request(
  File "/usr/local/lib/python3.10/site-packages/scrapelib/__init__.py", line 389, in request
    request_key = self.key_for_request(method, url, params)
TypeError: LegistarEventsScraper.key_for_request() takes 3 positional arguments but 4 were given; 27459)
```

Might have something to do with https://github.com/jamesturk/scrapelib/pull/164, but then I'm not sure why we haven't seen this error until now.