### PR TITLE
Remove key_for_request override from LegistarEventsScraper

### DIFF
--- a/legistar/events.py
+++ b/legistar/events.py
@@ -55,22 +55,8 @@ class LegistarEventsScraper(LegistarScraper):
     def should_cache_response(self, response):
         # Never cache the top level events page, because that may result in
         # expired .NET state values.
-        #
-        # works in concert with `key_for_request` to stop a request
-        # from using the cache
         return (super().should_cache_response(response) and
                 response.url != self.EVENTSPAGE)
-
-    def key_for_request(self, method, url, params):
-        # avoid attempting to pull top level events page from cache by
-        # making sure the key for that page is None
-        #
-        # works in concert with `should_cache_response` to stop a request
-        # from using the cache
-        if url == self.EVENTSPAGE:
-            return None
-
-        return super().key_for_request(method, url, params)
 
     def eventSearch(self, page, since):
         payload = self.sessionSecrets(page)


### PR DESCRIPTION
## Overview

Scrapelib's `Scraper.key_for_request()` function was [updated](https://github.com/jamesturk/scrapelib/blob/main/docs/changelog.md#230) to take more arguments. `LegistarEventsScraper.key_for_request()` hadn't been updated to reflect the change. 

Instead of updating `LegistarEventsScraper`, we decided the override was unnecessary so it's been removed altogether.