### PR TITLE
Don't retry 410, allow search results to be passed to APIEventScraper.events

### DIFF
--- a/legistar/base.py
+++ b/legistar/base.py
@@ -359,9 +359,10 @@ class LegistarAPIScraper(scrapelib.Scraper):
             page_num += 1
 
     def accept_response(self, response, **kwargs):
-        '''
+        """
         This overrides a method that controls whether
         the scraper should retry on an error. We don't
-        want to retry if the API returns a 400
-        '''
-        return response.status_code < 401
+        want to retry if the API returns a 400, except for
+        410, which means the record no longer exists.
+        """
+        return response.status_code < 401 or response.status_code == 410

--- a/legistar/events.py
+++ b/legistar/events.py
@@ -238,8 +238,9 @@ class LegistarAPIEventScraperBase(LegistarAPIScraper, metaclass=ABCMeta):
                               params=params,
                               item_key="EventId")
 
-    def events(self, since_datetime=None):
-        for api_event in self.api_events(since_datetime=since_datetime):
+    def events(self, since_datetime=None, api_events=None):
+
+        for api_event in api_events or self.api_events(since_datetime=since_datetime):
 
             time_str = api_event['EventTime']
             if not time_str:  # If we don't have an event time, skip it


### PR DESCRIPTION
This PR updates `accept_response` to prevent retries of requests with the 410 - Gone status code. It also breaks the event processing into its own method so it can be used in a loop or on a standalone event.